### PR TITLE
DISCO-14: Change to node require/export syntax to fix discovery unit …

### DIFF
--- a/lib/common-util.js
+++ b/lib/common-util.js
@@ -1,7 +1,7 @@
-import * as Uuidv4 from 'uuid/v4';
-import * as Base64 from 'base64-js';
+const Uuidv4 = require('uuid/v4')
+const Base64 = require('base64-js')
 
-export const base64UUIDv4 = () => {
+const base64UUIDv4 = () => {
   const byteArray = new Uint8Array(16);
   Uuidv4(null, byteArray, 0);
 
@@ -27,7 +27,7 @@ export const base64UUIDv4 = () => {
 };
 
 // TODO : excellent candidate for test case,
-export const parseQueryStringToObject = (queryString, parameterWhiteList) => {
+const parseQueryStringToObject = (queryString, parameterWhiteList) => {
   const parmHash = {};
   if (queryString === null
         || queryString.length < 2
@@ -54,3 +54,8 @@ export const parseQueryStringToObject = (queryString, parameterWhiteList) => {
 
   return parmHash;
 };
+
+module.exports = {
+  base64UUIDv4,
+  parseQueryStringToObject,
+}

--- a/lib/user-info-stash.js
+++ b/lib/user-info-stash.js
@@ -1,11 +1,11 @@
-import * as CommonUtil from './common-util';
+const CommonUtil = require('./common-util')
 
 const USER_ID_PATH = 'user.id';
 const USER_EMAIL_PATH = 'user.email';
 
 let gUserId = null;
 
-export const getUserId = () => {
+const getUserId = () => {
   const storage = window.localStorage;
 
   if (!gUserId) {
@@ -24,7 +24,7 @@ export const getUserId = () => {
   return gUserId;
 };
 
-export const updateUserId = (userId) => {
+const updateUserId = (userId) => {
   const storage = window.localStorage;
 
   gUserId = userId;
@@ -37,13 +37,13 @@ export const updateUserId = (userId) => {
 // to notify the app of both the before and after Id so that analytics can be
 // updated to relate them
 
-export const updateEmailAddress = (emailAddress) => {
+const updateEmailAddress = (emailAddress) => {
   const storage = window.localStorage;
 
   storage.setItem(USER_EMAIL_PATH, emailAddress);
 };
 
-export const getEmailAddress = () => {
+const getEmailAddress = () => {
   const storage = window.localStorage;
 
   const emailAddress = storage.getItem(USER_EMAIL_PATH);
@@ -54,3 +54,10 @@ export const getEmailAddress = () => {
 
   return emailAddress;
 };
+
+module.exports = {
+  getUserId,
+  updateUserId,
+  updateEmailAddress,
+  getEmailAddress,
+}


### PR DESCRIPTION
ES6 import/export statements cause unit tests to fail in the discovery site when these libraries are pulled in as external library dependencies (due to code not being run through babel). We had to convert to Node require/export syntax as a workaround.